### PR TITLE
Fix Python 3.14 incompatibility with Union subscripting

### DIFF
--- a/rekuest_next/definition/define.py
+++ b/rekuest_next/definition/define.py
@@ -222,7 +222,7 @@ def convert_object_to_argport(
         # and convert hem to a new union
 
         non_nullable_args = [arg for arg in get_args(cls) if arg is not type(None)]
-        cls = Union.__getitem__(tuple(non_nullable_args))  # type: ignore
+        cls = Union[tuple(non_nullable_args)]  # type: ignore
         # TODO: We might want to handle this better
 
         return convert_object_to_argport(
@@ -521,7 +521,7 @@ def convert_object_to_returnport(
         # and convert hem to a new union
 
         non_nullable_args = [arg for arg in get_args(cls) if arg is not type(None)]
-        cls = Union.__getitem__(tuple(non_nullable_args))  # type: ignore
+        cls = Union[tuple(non_nullable_args)]  # type: ignore
         # TODO: We might want to handle this better
 
         return convert_object_to_returnport(

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -1,5 +1,7 @@
 """General Tests for defininin actions"""
 
+from typing import Optional
+
 from rekuest_next.api.schema import DefinitionInput, PortKind
 import pytest
 from rekuest_next.definition.define import prepare_definition
@@ -264,6 +266,40 @@ def test_explicit_name_takes_precedence(simple_registry: StructureRegistry) -> N
         some_action, structure_registry=simple_registry, name="Custom Name"
     )
     assert functional_definition.name == "Custom Name"
+
+
+@pytest.mark.define
+def test_nullable_optional_arg_and_return(simple_registry: StructureRegistry) -> None:
+    """Regression test for the nullable-union reconstruction (issue #15).
+
+    Both ``convert_object_to_argport`` and ``convert_object_to_returnport``
+    rebuild a new union from the non-``None`` members of an ``Optional`` type.
+    On Python 3.14 ``typing.Union`` became a real C class, so the previous
+    ``Union.__getitem__(tuple(...))`` call raised ``descriptor '__getitem__'
+    requires a 'typing.Union' object but received a 'tuple'``. This test hits
+    both the input and output branches to guard against a regression.
+    """
+
+    def optional_roundtrip(x: Optional[int]) -> Optional[str]:
+        """Return the value as a string, or ``None``.
+
+        Args:
+            x (int, optional): the input value
+        """
+        return None if x is None else str(x)
+
+    functional_definition = prepare_definition(
+        optional_roundtrip, structure_registry=simple_registry
+    )
+    assert isinstance(functional_definition, DefinitionInput), (
+        "output is not a definition"
+    )
+
+    assert functional_definition.args[0].nullable, "Arg should be nullable"
+    assert functional_definition.args[0].kind == PortKind.INT
+
+    assert functional_definition.returns[0].nullable, "Return should be nullable"
+    assert functional_definition.returns[0].kind == PortKind.STRING
 
 
 @pytest.mark.define


### PR DESCRIPTION
In Python 3.14, typing.Union was reimplemented in C as a real class
(CPython #132139), making Union.__getitem__ a descriptor that expects a
typing.Union instance as self rather than a tuple. Calling
Union.__getitem__(tuple(...)) now raises "descriptor '__getitem__'
requires a 'typing.Union' object but received a 'tuple'".

Use the standard subscript form Union[tuple(...)] instead, which works
across all supported Python versions and preserves the existing
single-arg collapse behavior.

Fixes #15

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013DpF299DrJ8ZfHAfMfcH9h